### PR TITLE
通过检测模组的方式修复 #4

### DIFF
--- a/src/main/java/com/xiaopiao/patternbetter/mixin/VerticalButtonBarMixin.java
+++ b/src/main/java/com/xiaopiao/patternbetter/mixin/VerticalButtonBarMixin.java
@@ -10,6 +10,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.renderer.Rect2i;
 import net.minecraft.resources.ResourceLocation;
+import net.neoforged.fml.ModList;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -47,7 +48,7 @@ public abstract class VerticalButtonBarMixin implements ICompositeWidget {
             guiGraphics.blitSprite(
                     rs,
                     bounds.getX() + this.getBounds().getX() +this.getBounds().getWidth() , // 修改X坐标计算
-                    bounds.getY() + this.getBounds().getY() - 1,
+                    bounds.getY() + this.getBounds().getY() + (ModList.get().isLoaded("appflux") || ModList.get().isLoaded("expandedae") ? 29 : -1),
                     1,
                     this.getBounds().getWidth() + 1,
                     this.getBounds().getHeight() + 4);
@@ -79,11 +80,11 @@ public abstract class VerticalButtonBarMixin implements ICompositeWidget {
 
             if (isRight){
                 button.setX(screenOrigin.getX() + position.getX() - MARGIN - button.getWidth() + getBounds().getWidth());
+                button.setY(screenOrigin.getY() + currentY + (ModList.get().isLoaded("appflux") || ModList.get().isLoaded("expandedae") ? 30 : 0));
             }else {
                 button.setX(screenOrigin.getX() + position.getX() - MARGIN - button.getWidth());
+                button.setY(screenOrigin.getY() + currentY);
             }
-
-            button.setY(screenOrigin.getY() + currentY);
 
             currentY += button.getHeight() + VERTICAL_SPACING;
             maxWidth = Math.max(button.getWidth(), maxWidth);


### PR DESCRIPTION
由于代码添加倍乘按钮的方式是[注入 VerticalButtonBar 类](https://github.com/mynamexiaopiao/patternbetter/blob/main/src/main/java/com/xiaopiao/patternbetter/mixin/VerticalButtonBarMixin.java)，此时难以获取升级卡的个数，因此目前修复 #4 的方法是通过检测“会增加升级卡槽的模组”实现的，并非最优解，但一定程度上能解决 GUI 重叠的问题。

效果如图：
<img width="458" height="452" alt="Snipaste_2025-10-18_11-18-00" src="https://github.com/user-attachments/assets/17a7d35a-29ef-455b-a84d-5bca24d1f320" />